### PR TITLE
update version info

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -12,7 +12,7 @@
 // build by the user have been successfully uploaded into firmware.
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__ // build date and time
 #ifndef STRING_CONFIG_H_AUTHOR
-#define STRING_CONFIG_H_AUTHOR "Tinker_18.11-DEV" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "Tinker_19.03.1-DEV" // Who made the changes.
 #endif
 
 // SERIAL_PORT selects which serial port should be used for communication with the host.


### PR DESCRIPTION
still displayed v18.11 - although this has been v19.03.1 for a while
should minimize confusion when trying to find out which version is active